### PR TITLE
New Smartbar icons to match Pixel theme

### DIFF
--- a/res/drawable/ic_skip_next.xml
+++ b/res/drawable/ic_skip_next.xml
@@ -1,9 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24.0"
-    android:viewportHeight="24.0">
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:pathData="M6,18l8.5,-6L6,6v12zM16,6v12h2V6h-2z" />
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
+
+    <group>
+        <path
+            android:fillColor="#ffffff"
+            android:pathData="M72,20h-4c-2.2,0-4,1.8-4,4v48c0,2.2,1.8,4,4,4h4c2.2,0,4-1.8,4-4V24C76,21.8,74.2,20,72,20z" />
+        <path
+            android:fillColor="#ffffff"
+            android:pathData="M54.5,44.9L54.5,44.9L54.5,44.9c-0.3-0.2-0.5-0.3-0.7-0.4L24.7,26.6c-0.1-0.1-0.2-0.1-0.3-0.2l-0.1-0.1l0,0
+C23.9,26.1,23.5,26,23,26c-1.7,0-3,1.3-3,3v38c0,1.7,1.3,3,3,3c0.5,0,1-0.1,1.5-0.4l0,0l0.2-0.1c0,0,0,0,0,0l29.1-17.9
+c0.2-0.1,0.4-0.2,0.6-0.4l0.1-0.1v0c0.9-0.7,1.5-1.8,1.5-3.1S55.4,45.6,54.5,44.9z" />
+    </group>
 </vector>

--- a/res/drawable/ic_skip_previous.xml
+++ b/res/drawable/ic_skip_previous.xml
@@ -1,9 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24.0"
-    android:viewportHeight="24.0">
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:pathData="M6,6h2v12L6,18zM9.5,12l8.5,6L18,6z" />
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
+    <group>
+        <path
+            android:fillColor="#ffffff"
+            android:pathData="M30,22h-4c-2.2,0-4,1.8-4,4v44c0,2.2,1.8,4,4,4h4c2.2,0,4-1.8,4-4V26C34,23.8,32.2,22,30,22z" />
+        <path
+            android:fillColor="#ffffff"
+            android:pathData="M71,30c-0.6,0-1.1,0.2-1.6,0.5l0,0L44,44.5v0c-1.2,0.7-2,2-2,3.4s0.8,2.8,2,3.4v0l25.3,14l0,0
+c0.5,0.3,1.1,0.5,1.7,0.5c1.7,0,3-1.3,3-3V33C74,31.3,72.7,30,71,30z" />
+    </group>
 </vector>

--- a/res/drawable/ic_sysbar_assist.xml
+++ b/res/drawable/ic_sysbar_assist.xml
@@ -1,8 +1,28 @@
-<!-- drawable/assistant.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path android:fillColor="@color/icon_color_search_assistant" android:pathData="M19,2H5A2,2 0 0,0 3,4V18A2,2 0 0,0 5,20H9L12,23L15,20H19A2,2 0 0,0 21,18V4A2,2 0 0,0 19,2M13.88,12.88L12,17L10.12,12.88L6,11L10.12,9.12L12,5L13.88,9.12L18,11" />
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
+    <path
+        android:fillColor="@color/icon_color_search_assistant"
+        android:pathData="M64,16H32c-3.3,0-6,2.7-6,6v30c0,1.4,0.5,2.7,1.3,3.7h0l17.6,22.8h0c0.7,0.9,1.9,1.5,3.1,1.5
+s2.4-0.6,3.1-1.5h0l17.4-22.6c0.9-1,1.4-2.4,1.4-3.8V22C70,18.7,67.3,16,64,16z
+M61.2,39.2L61.2,39.2l-9.6,2.4l-2.4,9.6h0
+C49,51.7,48.5,52,48,52s-1-0.3-1.2-0.8h0l-2.4-9.5l-9.7-2.5v0C34.3,39,34,38.5,34,38c0-0.5,0.3-1,0.8-1.2v0l9.6-2.4l2.4-9.5h0
+c0.1-0.5,0.6-0.9,1.2-0.9s1.1,0.4,1.2,0.9h0l2.4,9.5l9.6,2.4v0C61.7,37,62,37.5,62,38C62,38.5,61.7,39,61.2,39.2z" />
 </vector>

--- a/res/drawable/ic_sysbar_back.xml
+++ b/res/drawable/ic_sysbar_back.xml
@@ -1,32 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-    Copyright (c) 2015 SlimRoms
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
 
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+          http://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="16.533dp"
-    android:height="19dp"
-    android:viewportWidth="16.533"
-    android:viewportHeight="19">
+        android:width="28.0dp"
+        android:height="28.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
 
     <path
         android:fillColor="@color/icon_color_back"
-        android:pathData="M15.302
-18.984c-0.951-0.382-1.792-1.015-2.699-1.495-4.0596-2.373-8.1307-4.726-12.183-7.114-0.97268-0.7699-0.07257-1.938
-0.8444-2.2113 4.5924-2.693 9.1816-5.3901 13.783-8.0672 0.748-0.36831 1.612
-0.37985 1.471 1.1618 0 5.6328 0.04 11.268-0.007 16.9-0.116 0.537-0.659
-0.928-1.209 0.826zm-0.888-9.4812c-0.002-2.1896-0.003-4.3803-0.005-6.5699-3.747
-2.1938-7.4938 4.3898-11.241 6.5836 3.7493 2.1875 7.497 4.3775 11.251 6.5585
-0-2.191-0.003-4.381-0.005-6.5722z" />
+        android:pathData="M69,20c-0.8,0-1.5,0.2-2.2,0.5l0,0L25,42.8l0,0c-0.1,0.1-0.2,0.1-0.3,0.2c-1.6,1.1-2.7,2.9-2.7,5
+s1.1,3.9,2.7,5c0.1,0.1,0.2,0.1,0.3,0.2l0,0l19.5,10.4l21.8,11.7l0,0c0.2,0.1,0.5,0.3,0.8,0.4l0,0l0,0c0.6,0.2,1.2,0.4,1.9,0.4
+c2.8,0,5-2.2,5-5V25C74,22.2,71.8,20,69,20z" />
 </vector>

--- a/res/drawable/ic_sysbar_back_ime.xml
+++ b/res/drawable/ic_sysbar_back_ime.xml
@@ -1,38 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-    Copyright (c) 2015 SlimRoms
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
 
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+          http://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="21.756dp"
-    android:height="16dp"
-    android:viewportWidth="21.756"
-    android:viewportHeight="16">
+        android:width="28.0dp"
+        android:height="28.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
 
     <path
         android:fillColor="@color/icon_color_ime_switcher"
-        android:pathData="M10.758
-15.994c-0.277-0.039-0.457-0.105-0.648-0.234-0.1694-0.115-0.1404-0.075-2.1527-2.978-1.0521-1.517-3.2289-4.6575-4.8385-6.9782-1.6096-2.3219-2.9495-4.2556-2.9761-4.2979-0.10158-0.156-0.1427-0.2951-0.1427-0.4825
-0-0.19711 0.041117-0.33013 0.156-0.50185 0.17414-0.26364 0.5055-0.45834
-0.8586-0.50429 0.0641-0.008468 3.2652-0.013305 9.8994-0.015724 9.455-0.0036278
-9.808-0.0024185 9.903 0.01814 0.396 0.087074 0.702 0.30595 0.849 0.60828 0.068
-0.13908 0.088 0.22736 0.09 0.38334 0 0.156-0.023 0.26-0.087 0.3894-0.025
-0.0484-1.73 2.5287-3.788 5.5121-2.059 2.9822-4.24 6.1422-4.847 7.0202-0.746
-1.082-1.127 1.625-1.181 1.683-0.187 0.197-0.438 0.32-0.749 0.368-0.103
-0.015-0.271 0.021-0.346 0.01zm1.981-5.733c1.004-1.4544 2.669-3.8658 3.698-5.3581
-1.029-1.4911 1.895-2.7452 1.924-2.7863l0.053-0.0738h-7.53c-6.291 0-7.5293
-0.0025-7.5245 0.0158 0.0036 0.0084 0.5176 0.7534 1.1416 1.6543 4.1649 6.0067
-6.2919 9.0741 6.3379 9.1401 0.03 0.041 0.058 0.07 0.063 0.065 0.005-0.006
-0.832-1.201 1.837-2.657z" />
+        android:pathData="M69,20c-0.8,0-1.5,0.2-2.2,0.5l0,0L25,42.8l0,0c-0.1,0.1-0.2,0.1-0.3,0.2c-1.6,1.1-2.7,2.9-2.7,5
+s1.1,3.9,2.7,5c0.1,0.1,0.2,0.1,0.3,0.2l0,0l19.5,10.4l21.8,11.7l0,0c0.2,0.1,0.5,0.3,0.8,0.4l0,0l0,0c0.6,0.2,1.2,0.4,1.9,0.4
+c2.8,0,5-2.2,5-5V25C74,22.2,71.8,20,69,20z" />
 </vector>

--- a/res/drawable/ic_sysbar_back_land.xml
+++ b/res/drawable/ic_sysbar_back_land.xml
@@ -1,32 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-    Copyright (c) 2015 SlimRoms
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
 
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+          http://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="16.533dp"
-    android:height="19dp"
-    android:viewportWidth="16.533"
-    android:viewportHeight="19">
+        android:width="28.0dp"
+        android:height="28.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
 
     <path
         android:fillColor="@color/icon_color_back"
-        android:pathData="M15.302
-18.984c-0.951-0.382-1.792-1.015-2.699-1.495-4.0596-2.373-8.1307-4.726-12.183-7.114-0.97268-0.7699-0.07257-1.938
-0.8444-2.2113 4.5924-2.693 9.1816-5.3901 13.783-8.0672 0.748-0.36831 1.612
-0.37985 1.471 1.1618 0 5.6328 0.04 11.268-0.007 16.9-0.116 0.537-0.659
-0.928-1.209 0.826zm-0.888-9.4812c-0.002-2.1896-0.003-4.3803-0.005-6.5699-3.747
-2.1938-7.4938 4.3898-11.241 6.5836 3.7493 2.1875 7.497 4.3775 11.251 6.5585
-0-2.191-0.003-4.381-0.005-6.5722z" />
+        android:pathData="M69,20c-0.8,0-1.5,0.2-2.2,0.5l0,0L25,42.8l0,0c-0.1,0.1-0.2,0.1-0.3,0.2c-1.6,1.1-2.7,2.9-2.7,5
+s1.1,3.9,2.7,5c0.1,0.1,0.2,0.1,0.3,0.2l0,0l19.5,10.4l21.8,11.7l0,0c0.2,0.1,0.5,0.3,0.8,0.4l0,0l0,0c0.6,0.2,1.2,0.4,1.9,0.4
+c2.8,0,5-2.2,5-5V25C74,22.2,71.8,20,69,20z" />
 </vector>

--- a/res/drawable/ic_sysbar_bt.xml
+++ b/res/drawable/ic_sysbar_bt.xml
@@ -1,8 +1,31 @@
-<!-- drawable/bluetooth.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path android:fillColor="@color/icon_color_bluetooth" android:pathData="M14.88,16.29L13,18.17V14.41M13,5.83L14.88,7.71L13,9.58M17.71,7.71L12,2H11V9.58L6.41,5L5,6.41L10.59,12L5,17.58L6.41,19L11,14.41V22H12L17.71,16.29L13.41,12L17.71,7.71Z" />
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
+
+    <group>
+        <path
+            android:fillColor="@color/icon_color_bluetooth"
+            android:pathData="M70.7,58.5L70.7,58.5L70.7,58.5c-0.1,0-0.1-0.1-0.2-0.1l-12.5-7l-1.1-0.6C55.8,50.3,55,49.3,55,48
+c0-1.1,0.7-2.1,1.6-2.6l1-0.5l0.4-0.2l12.5-7c0.1,0,0.1-0.1,0.2-0.1l0,0v0C71.5,36.9,72,36,72,35s-0.5-1.9-1.3-2.5v0l0,0
+c-0.2-0.2-0.5-0.3-0.7-0.4L46.1,20.6l0,0C45.5,20.2,44.8,20,44,20c-2.2,0-4,1.8-4,4v13.7L32,33c-1.9-1.1-4.4-0.5-5.5,1.5l-2,3.5
+c-1.1,1.9-0.5,4.4,1.5,5.5l7.9,4.6L26,52.6c-1.9,1.1-2.6,3.6-1.5,5.5l2,3.5c1.1,1.9,3.6,2.6,5.5,1.5l8-4.6V72c0,2.2,1.8,4,4,4
+c0.8,0,1.5-0.2,2.1-0.6l0,0L70,63.8c0.3-0.1,0.5-0.2,0.7-0.4h0C71.5,62.9,72,62,72,61S71.5,59.1,70.7,58.5z" />
+    </group>
 </vector>

--- a/res/drawable/ic_sysbar_clear_notifications.xml
+++ b/res/drawable/ic_sysbar_clear_notifications.xml
@@ -1,8 +1,31 @@
-<!-- drawable/clear_notifications.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path android:fillColor="@color/icon_color_clear_notifications" android:pathData="M5,13H19V11H5M3,17H17V15H3M7,7V9H21V7" />
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
+
+    <path
+        android:fillColor="@color/icon_color_clear_notifications"
+        android:pathData="M78,32H38c-2.2,0-4-1.8-4-4v-4c0-2.2,1.8-4,4-4h40c2.2,0,4,1.8,4,4v4C82,30.2,80.2,32,78,32z" />
+    <path
+        android:fillColor="@color/icon_color_clear_notifications"
+        android:pathData="M68,54H28c-2.2,0-4-1.8-4-4v-4c0-2.2,1.8-4,4-4h40c2.2,0,4,1.8,4,4v4C72,52.2,70.2,54,68,54z" />
+    <path
+        android:fillColor="@color/icon_color_clear_notifications"
+        android:pathData="M58,76H18c-2.2,0-4-1.8-4-4v-4c0-2.2,1.8-4,4-4h40c2.2,0,4,1.8,4,4v4C62,74.2,60.2,76,58,76z" />
 </vector>

--- a/res/drawable/ic_sysbar_docked.xml
+++ b/res/drawable/ic_sysbar_docked.xml
@@ -1,8 +1,29 @@
-<!-- drawable/layers.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path android:fillColor="@color/icon_color_split_screen" android:pathData="M12,16L19.36,10.27L21,9L12,2L3,9L4.63,10.27M12,18.54L4.62,12.81L3,14.07L12,21.07L21,14.07L19.37,12.8L12,18.54Z" />
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
+    <group>
+        <path
+            android:fillColor="#ffffff"
+            android:pathData="M74,20h-2H24h-2c-3.3,0-6,2.7-6,6v12c0,3.3,2.7,6,6,6h52c3.3,0,6-2.7,6-6V26C80,22.7,77.3,20,74,20z" />
+        <path
+            android:fillColor="#ffffff"
+            android:pathData="M74,52H22c-3.3,0-6,2.7-6,6v12c0,3.3,2.7,6,6,6h2h48h2c3.3,0,6-2.7,6-6V58C80,54.7,77.3,52,74,52z" />
+    </group>
 </vector>

--- a/res/drawable/ic_sysbar_editing_smartbar.xml
+++ b/res/drawable/ic_sysbar_editing_smartbar.xml
@@ -1,8 +1,35 @@
-<!-- drawable/editing_smartbar.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path android:fillColor="@color/icon_color_editing_smartbar" android:pathData="M4,2H20A2,2 0 0,1 22,4V16A2,2 0 0,1 20,18H16L12,22L8,18H4A2,2 0 0,1 2,16V4A2,2 0 0,1 4,2M18,14V12H12.5L10.5,14H18M6,14H8.5L15.35,7.12C15.55,6.93 15.55,6.61 15.35,6.41L13.59,4.65C13.39,4.45 13.07,4.45 12.88,4.65L6,11.53V14Z" />
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
+    <group>
+        <path
+            android:fillColor="@color/icon_color_editing_smartbar"
+            android:pathData="M64.3,42.5L64.3,42.5C64.3,42.5,64.3,42.5,64.3,42.5L53.5,31.7c-0.6-0.6-1.4-1-2.3-1s-1.7,0.4-2.3,1h0
+L25.3,55.3c-0.4,0.3-0.6,0.8-0.8,1.2l0,0l-0.1,0.4c0,0,0,0.1,0,0.1l-4.2,14.6l0,0C20.1,72,20,72.4,20,72.8c0,1.8,1.4,3.2,3.2,3.2
+c0.4,0,0.7-0.1,1.1-0.2l0,0l14.5-4.1l0-0.1c0.8-0.1,1.4-0.5,1.9-1.1l23.5-23.5c0,0,0,0,0,0l0,0v0c0.6-0.6,0.9-1.4,0.9-2.2
+C65.2,43.9,64.9,43.1,64.3,42.5L64.3,42.5z" />
+        <path
+            android:fillColor="@color/icon_color_editing_smartbar"
+            android:pathData="M75.2,31.9L75.2,31.9L75.2,31.9c-0.1-0.1-0.1-0.2-0.2-0.2L64.3,21c0,0-0.1-0.1-0.1-0.1l0,0h0
+C63.6,20.3,62.8,20,62,20s-1.6,0.3-2.2,0.9h0l0,0c0,0-0.1,0.1-0.1,0.1l-2.1,2.1c0,0,0,0,0,0l0,0v0c-0.6,0.6-0.9,1.4-0.9,2.2
+c0,0.9,0.3,1.7,0.9,2.2v0l0,0c0,0,0,0,0,0l10.7,10.7c0.1,0.1,0.1,0.1,0.2,0.2l0,0h0c0.6,0.5,1.3,0.8,2.1,0.8c0.8,0,1.6-0.3,2.1-0.8
+h0l0.1-0.1c0,0,0,0,0,0l2.1-2.1c0,0,0.1-0.1,0.1-0.1l0.1-0.1v0c0.5-0.6,0.8-1.3,0.8-2.1S75.7,32.4,75.2,31.9z" />
+    </group>
 </vector>

--- a/res/drawable/ic_sysbar_expanded_desktop.xml
+++ b/res/drawable/ic_sysbar_expanded_desktop.xml
@@ -1,8 +1,35 @@
-<!-- drawable/arrow_expand.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path android:fillColor="@color/icon_color_expanded_desktop" android:pathData="M9.5,13.09L10.91,14.5L6.41,19H10V21H3V14H5V17.59L9.5,13.09M10.91,9.5L9.5,10.91L5,6.41V10H3V3H10V5H6.41L10.91,9.5M14.5,13.09L19,17.59V14H21V21H14V19H17.59L13.09,14.5L14.5,13.09M13.09,9.5L17.59,5H14V3H21V10H19V6.41L14.5,10.91L13.09,9.5Z" />
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
+
+
+    <group>
+        <path
+            android:fillColor="@color/icon_color_expanded_desktop"
+            android:pathData="M22,40h52c2.2,0,4-1.8,4-4c0-0.7-0.2-1.4-0.5-1.9l0,0l-0.1-0.1c-0.1-0.1-0.2-0.3-0.3-0.4l-7.9-11.3
+c0-0.1-0.1-0.1-0.1-0.1L69,22l0,0C68,20.8,66.6,20,65,20H31c-1.6,0-3.1,0.8-4,2l0,0l-0.1,0.1c0,0,0,0.1-0.1,0.1l-8,11.4
+c-0.1,0.1-0.1,0.2-0.2,0.3l-0.1,0.1l0,0c-0.4,0.6-0.6,1.3-0.6,2C18,38.2,19.8,40,22,40z" />
+        <path
+            android:fillColor="@color/icon_color_expanded_desktop"
+            android:pathData="M74,56H22c-2.2,0-4,1.8-4,4c0,0.8,0.2,1.4,0.6,2l0,0l0.1,0.1c0.1,0.1,0.1,0.2,0.2,0.3l8,11.4
+c0,0,0,0.1,0.1,0.1L27,74l0,0c0.9,1.2,2.4,2,4,2h34c1.6,0,3-0.8,3.9-1.9l0,0l0.1-0.2c0,0,0.1-0.1,0.1-0.1l7.9-11.3
+c0.1-0.1,0.2-0.3,0.3-0.4l0.1-0.1l0,0c0.3-0.6,0.5-1.2,0.5-1.9C78,57.8,76.2,56,74,56z" />
+    </group>
 </vector>

--- a/res/drawable/ic_sysbar_google_now_on_tap.xml
+++ b/res/drawable/ic_sysbar_google_now_on_tap.xml
@@ -1,8 +1,27 @@
-<!-- drawable/google-glass.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path android:fillColor="@color/icon_color_google_now_on_tap" android:pathData="M13,11V13.5H18.87C18.26,17 15.5,19.5 12,19.5A7.5,7.5 0 0,1 4.5,12A7.5,7.5 0 0,1 12,4.5C14.09,4.5 15.9,5.39 17.16,6.84L18.93,5.06C17.24,3.18 14.83,2 12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22C17.5,22 21.5,17.5 21.5,12V11H13Z" />
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
+    <path
+        android:fillColor="@color/icon_color_google_now_on_tap"
+        android:pathData="M72,42h-4h-4H48c-2.2,0-4,1.8-4,4v4c0,2.2,1.8,4,4,4h14.8c-2.4,5.9-8.1,10-14.8,10c-8.8,0-16-7.2-16-16
+s7.2-16,16-16c2.9,0,5.6,0.8,7.9,2.1l0,0c0.4,0.3,0.8,0.5,1.3,0.5c0.6,0,1.1-0.2,1.4-0.6l0,0l5.9-5.6c0,0,0,0,0.1-0.1l0,0l0,0
+c0.3-0.4,0.5-0.8,0.5-1.4c0-0.6-0.3-1.1-0.7-1.5l0,0c0,0-0.1,0-0.1-0.1c-0.1-0.1-0.2-0.1-0.2-0.2C59.7,21.9,54.1,20,48,20
+c-15.5,0-28,12.5-28,28c0,15.5,12.5,28,28,28s28-12.5,28-28v-2C76,43.8,74.2,42,72,42z" />
 </vector>

--- a/res/drawable/ic_sysbar_home.xml
+++ b/res/drawable/ic_sysbar_home.xml
@@ -1,42 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-    Copyright (c) 2015 SlimRoms
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
 
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+          http://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="17.995dp"
-    android:height="18dp"
-    android:viewportWidth="17.995"
-    android:viewportHeight="18">
-
+        android:width="28.0dp"
+        android:height="28.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
     <path
         android:fillColor="@color/icon_color_home"
-        android:pathData="M8.5764
-17.99c-0.368-0.017-0.8101-0.067-1.1731-0.133-2.3603-0.428-4.4486-1.781-5.8247-3.775-1.1772-1.706-1.7253-3.787-1.5452-5.8608
-0.15796-1.8132 0.86104-3.5284 2.0222-4.9366 1.2272-1.4862 2.8874-2.5403
-4.7396-3.0094 1.2071-0.30602 2.4453-0.35703 3.6888-0.152 1.324 0.21802 2.624
-0.75709 3.722 1.5422 1.972 1.4092 3.288 3.5164 3.676 5.8837 0.085 0.5131 0.114
-0.8921 0.113 1.4612 0 0.434-0.011 0.6421-0.053 1.0147-0.178 1.57-0.782
-3.086-1.733 4.353-1.809 2.408-4.646 3.751-7.6326
-3.612zm0.8491-2.178c1.5465-0.102 2.9585-0.686 4.1045-1.698 0.134-0.118
-0.427-0.41 0.552-0.549 0.867-0.968 1.432-2.139 1.646-3.413 0.067-0.3916
-0.095-0.7376 0.095-1.1517
-0-0.3-0.009-0.4781-0.04-0.7641-0.215-1.9882-1.313-3.7965-2.982-4.9126-0.447-0.298-0.99-0.5721-1.48-0.7471-0.62-0.22-1.223-0.344-1.8925-0.389-0.189-0.012-0.6661-0.012-0.8571
-0-1.5592 0.103-2.9844 0.6991-4.1365 1.7302-0.139 0.125-0.431 0.419-0.5491
-0.552-0.9331 1.0582-1.5191 2.3793-1.6682 3.7665-0.031 0.285-0.04 0.4571-0.04
-0.7641s0.009 0.4781 0.04 0.7641c0.1491 1.3866 0.7351 2.7086 1.6682 3.7656 0.1171
-0.132 0.4091 0.426 0.5491 0.552 1.0321 0.926 2.3093 1.51 3.6815 1.686 0.104
-0.013 0.253 0.028 0.331 0.034 0.079 0.006 0.161 0.012 0.183 0.014 0.099 0.008
-0.6591 0.005 0.7951-0.004z" />
+        android:pathData="M 48 20 C 63.4639729953 20 76 32.5360270047 76 48 C 76 63.4639729953 63.4639729953 76 48 76 C 32.5360270047 76 20 63.4639729953 20 48 C 20 32.5360270047 32.5360270047 20 48 20 Z" />
+    <path
+        android:fillColor="@color/icon_color_home"
+        android:pathData="M48,10c-21,0-38,17-38,38s17,38,38,38s38-17,38-38S69,10,48,10z
+M48,82c-18.8,0-34-15.2-34-34
+c0-18.8,15.2-34,34-34s34,15.2,34,34C82,66.8,66.8,82,48,82z" />
 </vector>

--- a/res/drawable/ic_sysbar_home_land.xml
+++ b/res/drawable/ic_sysbar_home_land.xml
@@ -1,42 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-    Copyright (c) 2015 SlimRoms
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
 
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+          http://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="17.995dp"
-    android:height="18dp"
-    android:viewportWidth="17.995"
-    android:viewportHeight="18">
-
+        android:width="28.0dp"
+        android:height="28.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
     <path
         android:fillColor="@color/icon_color_home"
-        android:pathData="M8.5764
-17.99c-0.368-0.017-0.8101-0.067-1.1731-0.133-2.3603-0.428-4.4486-1.781-5.8247-3.775-1.1772-1.706-1.7253-3.787-1.5452-5.8608
-0.15796-1.8132 0.86104-3.5284 2.0222-4.9366 1.2272-1.4862 2.8874-2.5403
-4.7396-3.0094 1.2071-0.30602 2.4453-0.35703 3.6888-0.152 1.324 0.21802 2.624
-0.75709 3.722 1.5422 1.972 1.4092 3.288 3.5164 3.676 5.8837 0.085 0.5131 0.114
-0.8921 0.113 1.4612 0 0.434-0.011 0.6421-0.053 1.0147-0.178 1.57-0.782
-3.086-1.733 4.353-1.809 2.408-4.646 3.751-7.6326
-3.612zm0.8491-2.178c1.5465-0.102 2.9585-0.686 4.1045-1.698 0.134-0.118
-0.427-0.41 0.552-0.549 0.867-0.968 1.432-2.139 1.646-3.413 0.067-0.3916
-0.095-0.7376 0.095-1.1517
-0-0.3-0.009-0.4781-0.04-0.7641-0.215-1.9882-1.313-3.7965-2.982-4.9126-0.447-0.298-0.99-0.5721-1.48-0.7471-0.62-0.22-1.223-0.344-1.8925-0.389-0.189-0.012-0.6661-0.012-0.8571
-0-1.5592 0.103-2.9844 0.6991-4.1365 1.7302-0.139 0.125-0.431 0.419-0.5491
-0.552-0.9331 1.0582-1.5191 2.3793-1.6682 3.7665-0.031 0.285-0.04 0.4571-0.04
-0.7641s0.009 0.4781 0.04 0.7641c0.1491 1.3866 0.7351 2.7086 1.6682 3.7656 0.1171
-0.132 0.4091 0.426 0.5491 0.552 1.0321 0.926 2.3093 1.51 3.6815 1.686 0.104
-0.013 0.253 0.028 0.331 0.034 0.079 0.006 0.161 0.012 0.183 0.014 0.099 0.008
-0.6591 0.005 0.7951-0.004z" />
+        android:pathData="M 48 20 C 63.4639729953 20 76 32.5360270047 76 48 C 76 63.4639729953 63.4639729953 76 48 76 C 32.5360270047 76 20 63.4639729953 20 48 C 20 32.5360270047 32.5360270047 20 48 20 Z" />
+    <path
+        android:fillColor="@color/icon_color_home"
+        android:pathData="M48,10c-21,0-38,17-38,38s17,38,38,38s38-17,38-38S69,10,48,10z
+M48,82c-18.8,0-34-15.2-34-34
+c0-18.8,15.2-34,34-34s34,15.2,34,34C82,66.8,66.8,82,48,82z" />
 </vector>

--- a/res/drawable/ic_sysbar_hotspot.xml
+++ b/res/drawable/ic_sysbar_hotspot.xml
@@ -1,8 +1,28 @@
-<!-- drawable/access_point_network.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path android:fillColor="@color/icon_color_hotspot" android:pathData="M4.93,2.93C3.12,4.74 2,7.24 2,10C2,12.76 3.12,15.26 4.93,17.07L6.34,15.66C4.89,14.22 4,12.22 4,10C4,7.79 4.89,5.78 6.34,4.34L4.93,2.93M19.07,2.93L17.66,4.34C19.11,5.78 20,7.79 20,10C20,12.22 19.11,14.22 17.66,15.66L19.07,17.07C20.88,15.26 22,12.76 22,10C22,7.24 20.88,4.74 19.07,2.93M7.76,5.76C6.67,6.85 6,8.35 6,10C6,11.65 6.67,13.15 7.76,14.24L9.17,12.83C8.45,12.11 8,11.11 8,10C8,8.89 8.45,7.89 9.17,7.17L7.76,5.76M16.24,5.76L14.83,7.17C15.55,7.89 16,8.89 16,10C16,11.11 15.55,12.11 14.83,12.83L16.24,14.24C17.33,13.15 18,11.65 18,10C18,8.35 17.33,6.85 16.24,5.76M12,8A2,2 0 0,0 10,10A2,2 0 0,0 12,12A2,2 0 0,0 14,10A2,2 0 0,0 12,8M11,14V18H10A1,1 0 0,0 9,19H2V21H9A1,1 0 0,0 10,22H14A1,1 0 0,0 15,21H22V19H15A1,1 0 0,0 14,18H13V14H11Z" />
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
+    <path
+        android:fillColor="@color/icon_color_hotspot"
+        android:pathData="M74,22.3c0-2.4-1.9-4.3-4.3-4.3H26.3c-2.4,0-4.3,1.9-4.3,4.3c0,0.9,0.3,1.8,0.8,2.5l0,0L42,59.5V66v4v4
+c0,2.2,1.8,4,4,4h4c2.2,0,4-1.8,4-4v-4v-4v-6.5l19.3-34.9l0,0C73.8,23.9,74,23.2,74,22.3z
+M62.8,27.8l-3,5.9c0,0.1-0.1,0.2-0.1,0.3
+l0,0.1l0,0c-0.4,0.5-1,0.9-1.7,0.9H38c-0.7,0-1.3-0.4-1.7-0.9l0,0l0,0c-0.1-0.1-0.1-0.2-0.2-0.3l-3-5.9C33.1,27.5,33,27.3,33,27
+c0-1.1,0.9-2,2-2h26c1.1,0,2,0.9,2,2C63,27.3,62.9,27.6,62.8,27.8L62.8,27.8z" />
 </vector>

--- a/res/drawable/ic_sysbar_ime_down.xml
+++ b/res/drawable/ic_sysbar_ime_down.xml
@@ -1,8 +1,25 @@
-<!-- drawable/chevron_down.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path android:fillColor="@color/icon_color_ime_down" android:pathData="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z" />
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
+    <path
+        android:fillColor="@color/icon_color_ime_down"
+        android:pathData="M51.9,42.1L51.9,42.1c-3.6,3.7-7,0.8-7.6,0.1L33.1,30.9c-1.2-1.2-3.1-1.2-4.2,0l-6,6c-1.2,1.2-1.2,3.1,0,4.2
+l22.3,23.7c1.6,1.6,4.1,1.6,5.7,0l22.3-23.7c1.2-1.2,1.2-3.1,0-4.2l-6-6c-1.2-1.2-3.1-1.2-4.2,0L51.9,42.1z" />
 </vector>

--- a/res/drawable/ic_sysbar_ime_left.xml
+++ b/res/drawable/ic_sysbar_ime_left.xml
@@ -1,8 +1,25 @@
-<!-- drawable/chevron_left.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path android:fillColor="@color/icon_color_ime_left" android:pathData="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z" />
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
+    <path
+        android:fillColor="@color/icon_color_ime_left"
+        android:pathData="M53.9,51.9L53.9,51.9c-3.7-3.6-0.8-7-0.1-7.6l11.3-11.1c1.2-1.2,1.2-3.1,0-4.2l-6-6c-1.2-1.2-3.1-1.2-4.2,0
+L31.2,45.2c-1.6,1.6-1.6,4.1,0,5.7l23.7,22.3c1.2,1.2,3.1,1.2,4.2,0l6-6c1.2-1.2,1.2-3.1,0-4.2L53.9,51.9z" />
 </vector>

--- a/res/drawable/ic_sysbar_ime_right.xml
+++ b/res/drawable/ic_sysbar_ime_right.xml
@@ -1,8 +1,25 @@
-<!-- drawable/chevron_right.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path android:fillColor="@color/icon_color_ime_right" android:pathData="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z" />
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
+    <path
+        android:fillColor="@color/icon_color_ime_right"
+        android:pathData="M42.1,51.9L42.1,51.9c3.7-3.6,0.8-7,0.1-7.6L30.9,33.1c-1.2-1.2-1.2-3.1,0-4.2l6-6c1.2-1.2,3.1-1.2,4.2,0
+l23.7,22.3c1.6,1.6,1.6,4.1,0,5.7L41.1,73.1c-1.2,1.2-3.1,1.2-4.2,0l-6-6c-1.2-1.2-1.2-3.1,0-4.2L42.1,51.9z" />
 </vector>

--- a/res/drawable/ic_sysbar_ime_up.xml
+++ b/res/drawable/ic_sysbar_ime_up.xml
@@ -1,8 +1,25 @@
-<!-- drawable/chevron_up.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path android:fillColor="@color/icon_color_ime_up" android:pathData="M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z" />
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
+    <path
+        android:fillColor="@color/icon_color_ime_up"
+        android:pathData="M51.9,53.9L51.9,53.9c-3.6-3.7-7-0.8-7.6-0.1L33.1,65.1c-1.2,1.2-3.1,1.2-4.2,0l-6-6c-1.2-1.2-1.2-3.1,0-4.2
+l22.3-23.7c1.6-1.6,4.1-1.6,5.7,0l22.3,23.7c1.2,1.2,1.2,3.1,0,4.2l-6,6c-1.2,1.2-3.1,1.2-4.2,0L51.9,53.9z" />
 </vector>

--- a/res/drawable/ic_sysbar_in_app_search.xml
+++ b/res/drawable/ic_sysbar_in_app_search.xml
@@ -1,8 +1,26 @@
-<!-- drawable/binoculars.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path android:fillColor="@color/icon_color_in_app_search" android:pathData="M11,6H13V13H11V6M9,20A1,1 0 0,1 8,21H5A1,1 0 0,1 4,20V15L6,6H10V13A1,1 0 0,1 9,14V20M10,5H7V3H10V5M15,20V14A1,1 0 0,1 14,13V6H18L20,15V20A1,1 0 0,1 19,21H16A1,1 0 0,1 15,20M14,5V3H17V5H14Z" />
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
+    <path
+        android:fillColor="@color/icon_color_in_app_search"
+        android:pathData="M78.8,65.2L65.9,52.2C67.3,49.1,68,45.6,68,42c0-14.4-11.6-26-26-26S16,27.6,16,42c0,14.4,11.6,26,26,26
+c3.6,0,7.1-0.7,10.2-2.1l12.9,12.9c1.6,1.6,4.1,1.6,5.7,0l8-8C80.4,69.3,80.4,66.7,78.8,65.2z
+M42,56c-7.7,0-14-6.3-14-14 s6.3-14,14-14s14,6.3,14,14S49.7,56,42,56z" />
 </vector>

--- a/res/drawable/ic_sysbar_killtask.xml
+++ b/res/drawable/ic_sysbar_killtask.xml
@@ -1,8 +1,31 @@
-<!-- drawable/close_circle_outline.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path android:fillColor="@color/icon_color_force_close_app" android:pathData="M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2C6.47,2 2,6.47 2,12C2,17.53 6.47,22 12,22C17.53,22 22,17.53 22,12C22,6.47 17.53,2 12,2M14.59,8L12,10.59L9.41,8L8,9.41L10.59,12L8,14.59L9.41,16L12,13.41L14.59,16L16,14.59L13.41,12L16,9.41L14.59,8Z" />
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
+    <path
+        android:fillColor="@color/icon_color_force_close_app"
+        android:pathData="M75.3,62.1L75.3,62.1c-0.2-0.2-0.2-0.3-0.3-0.3L61.2,48l13.9-13.9c0.6-0.6,0.9-1.4,0.9-2.3
+c0-0.9-0.4-1.8-1.1-2.4l-8.4-8.4c-0.1-0.1-0.1-0.1-0.2-0.2l-0.1-0.1h0c-0.6-0.5-1.3-0.8-2.1-0.8s-1.5,0.3-2.1,0.8h0L62,20.8
+c-0.1,0.1-0.2,0.2-0.2,0.2L48,34.8L34.2,21.1c-0.1-0.1-0.2-0.2-0.2-0.2l-0.1-0.1h0c-0.6-0.5-1.3-0.8-2.1-0.8s-1.5,0.3-2.1,0.8h0
+l-0.1,0.1c-0.1,0.1-0.1,0.1-0.2,0.2l-8.4,8.4c-0.6,0.6-1.1,1.4-1.1,2.4c0,0.9,0.4,1.7,0.9,2.3L34.8,48L21.1,61.8
+c-0.1,0.1-0.2,0.2-0.2,0.2l-0.1,0.1v0c-0.5,0.6-0.7,1.3-0.7,2s0.3,1.5,0.7,2v0l0.1,0.1c0,0.1,0.1,0.1,0.1,0.1l8.5,8.5
+c0,0.1,0.1,0.1,0.1,0.1l0.1,0.1h0c0.6,0.5,1.3,0.8,2.1,0.8c0.8,0,1.5-0.3,2.1-0.8h0l0.1-0.1c0,0,0,0,0,0L48,61.2l13.9,13.9
+c0,0,0,0,0,0l0.1,0.1h0c0.6,0.5,1.3,0.8,2.1,0.8c0.8,0,1.5-0.3,2.1-0.8h0l0.1-0.1c0.1,0,0.1-0.1,0.1-0.1l8.5-8.5
+c0.1,0,0.1-0.1,0.1-0.1l0.1-0.1v0c0.5-0.6,0.7-1.3,0.7-2S75.7,62.7,75.3,62.1L75.3,62.1z" />
 </vector>

--- a/res/drawable/ic_sysbar_lastapp.xml
+++ b/res/drawable/ic_sysbar_lastapp.xml
@@ -1,8 +1,27 @@
-<!-- drawable/arrange_bring_forward.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path android:fillColor="@color/icon_color_last_app" android:pathData="M2,2H16V16H2V2M22,8V22H8V18H10V20H20V10H18V8H22Z" />
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
+    <path
+        android:fillColor="@color/icon_color_last_app"
+        android:pathData="M78,45c0-1.7-1.3-3-3-3c-1.7,0-3,1.3-3,3c0,0-3.5,17-14,17s-10-8.3-10-10h8c2.2,0,4-1.8,4-4
+c0-0.7-0.2-1.4-0.5-2l0,0l-0.1-0.1c-0.1-0.2-0.2-0.3-0.4-0.5L41.6,21.5c-0.1-0.2-0.3-0.4-0.4-0.6l0,0h0C40.6,20.4,39.9,20,39,20
+s-1.6,0.4-2.2,0.9h0l0,0c-0.2,0.2-0.3,0.4-0.4,0.6L19.2,45.2c-0.3,0.3-0.5,0.6-0.7,0.9l-0.1,0.1l0,0C18.2,46.7,18,47.3,18,48
+c0,2.2,1.8,4,4,4h6c0,0.1,0,0.1,0,0.2c0,0,0,0.1,0,0.2C28.1,55.2,29.5,76,52,76c0,0,0,0,0,0C78.5,76,78,45,78,45z" />
 </vector>

--- a/res/drawable/ic_sysbar_menu.xml
+++ b/res/drawable/ic_sysbar_menu.xml
@@ -1,32 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-    Copyright (c) 2015 SlimRoms
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
 
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+          http://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="3dp"
-    android:height="18dp"
-    android:viewportWidth="3"
-    android:viewportHeight="18">
+    android:width="30.0dp"
+    android:height="30.0dp"
+    android:viewportWidth="512.000000"
+    android:viewportHeight="512.000000">
 
-    <path
-        android:fillColor="@color/icon_color_menu"
-        android:pathData="M1.5055 0.0056781c-1.0322-0.1002-1.8213 1.1022-1.3807 2.004 0.36229 1.0021
-1.7679 1.3027 2.4559 0.501 0.798-0.7014
-0.3928-2.2044-0.6743-2.505l-0.4009-0.0000219zm0 7.5152c-1.0322-0.1002-1.8213
-1.1022-1.3807 2.004 0.36229 1.0021 1.7679 1.3031 2.4559 0.5011 0.798-0.7015
-0.3928-2.2045-0.6743-2.5051h-0.4009zm0 7.5151c-1.0322-0.1-1.8213 1.102-1.3807
-2.004 0.36229 1.002 1.7679 1.303 2.4559 0.501 0.798-0.701
-0.3928-2.204-0.6743-2.505h-0.4009z" />
+    <group
+            android:translateY="96.000000"
+            android:scaleX="0.100000"
+            android:scaleY="-0.100000">
+        <path
+            android:fillColor="@color/icon_color_menu"
+            android:strokeWidth="1"
+            android:pathData="M217 732 c-22 -24 -21 -55 1 -75 16 -15 50 -17 264 -17 225 0 246 2 261 18 22 24
+21 55 -1 75 -16 15 -50 17 -264 17 -225 0 -246 -2 -261 -18z" />
+        <path
+            android:fillColor="@color/icon_color_menu"
+            android:strokeWidth="1"
+            android:pathData="M217 512 c-22 -24 -21 -55 1 -75 16 -15 50 -17 264 -17 225 0 246 2 261 18 22 24
+21 55 -1 75 -16 15 -50 17 -264 17 -225 0 -246 -2 -261 -18z" />
+        <path
+            android:fillColor="@color/icon_color_menu"
+            android:strokeWidth="1"
+            android:pathData="M217 302 c-22 -24 -21 -55 1 -75 16 -15 50 -17 264 -17 225 0 246 2 261 18 22 24
+21 55 -1 75 -16 15 -50 17 -264 17 -225 0 -246 -2 -261 -18z" />
+    </group>
 </vector>

--- a/res/drawable/ic_sysbar_menu_land.xml
+++ b/res/drawable/ic_sysbar_menu_land.xml
@@ -1,32 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-    Copyright (c) 2015 SlimRoms
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
 
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+          http://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="3dp"
-    android:height="18dp"
-    android:viewportWidth="3"
-    android:viewportHeight="18">
+    android:width="30.0dp"
+    android:height="30.0dp"
+    android:viewportWidth="512.000000"
+    android:viewportHeight="512.000000">
 
-    <path
-        android:fillColor="@color/icon_color_menu"
-        android:pathData="M1.5055 0.0056781c-1.0322-0.1002-1.8213 1.1022-1.3807 2.004 0.36229 1.0021
-1.7679 1.3027 2.4559 0.501 0.798-0.7014
-0.3928-2.2044-0.6743-2.505l-0.4009-0.0000219zm0 7.5152c-1.0322-0.1002-1.8213
-1.1022-1.3807 2.004 0.36229 1.0021 1.7679 1.3031 2.4559 0.5011 0.798-0.7015
-0.3928-2.2045-0.6743-2.5051h-0.4009zm0 7.5151c-1.0322-0.1-1.8213 1.102-1.3807
-2.004 0.36229 1.002 1.7679 1.303 2.4559 0.501 0.798-0.701
-0.3928-2.204-0.6743-2.505h-0.4009z" />
+    <group
+            android:translateY="96.000000"
+            android:scaleX="0.100000"
+            android:scaleY="-0.100000">
+        <path
+            android:fillColor="@color/icon_color_menu"
+            android:strokeWidth="1"
+            android:pathData="M217 732 c-22 -24 -21 -55 1 -75 16 -15 50 -17 264 -17 225 0 246 2 261 18 22 24
+21 55 -1 75 -16 15 -50 17 -264 17 -225 0 -246 -2 -261 -18z" />
+        <path
+            android:fillColor="@color/icon_color_menu"
+            android:strokeWidth="1"
+            android:pathData="M217 512 c-22 -24 -21 -55 1 -75 16 -15 50 -17 264 -17 225 0 246 2 261 18 22 24
+21 55 -1 75 -16 15 -50 17 -264 17 -225 0 -246 -2 -261 -18z" />
+        <path
+            android:fillColor="@color/icon_color_menu"
+            android:strokeWidth="1"
+            android:pathData="M217 302 c-22 -24 -21 -55 1 -75 16 -15 50 -17 264 -17 225 0 246 2 261 18 22 24
+21 55 -1 75 -16 15 -50 17 -264 17 -225 0 -246 -2 -261 -18z" />
+    </group>
 </vector>

--- a/res/drawable/ic_sysbar_no_action.xml
+++ b/res/drawable/ic_sysbar_no_action.xml
@@ -1,8 +1,27 @@
-<!-- drawable/block_helper.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path android:fillColor="@color/icon_color_no_action" android:pathData="M12,0A12,12 0 0,1 24,12A12,12 0 0,1 12,24A12,12 0 0,1 0,12A12,12 0 0,1 12,0M12,2A10,10 0 0,0 2,12C2,14.4 2.85,16.6 4.26,18.33L18.33,4.26C16.6,2.85 14.4,2 12,2M12,22A10,10 0 0,0 22,12C22,9.6 21.15,7.4 19.74,5.67L5.67,19.74C7.4,21.15 9.6,22 12,22Z" />
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
+    <path
+        android:fillColor="@color/icon_color_no_action"
+        android:pathData="M48,20c-15.5,0-28,12.5-28,28c0,15.5,12.5,28,28,28s28-12.5,28-28C76,32.5,63.5,20,48,20z
+M44,30
+c0-1.1,0.9-2,2-2h4c1.1,0,2,0.9,2,2v20c0,1.1-0.9,2-2,2h-4c-1.1,0-2-0.9-2-2V30z
+M48,68c-2.8,0-5-2.2-5-5s2.2-5,5-5s5,2.2,5,5 S50.8,68,48,68z" />
 </vector>

--- a/res/drawable/ic_sysbar_notification_panel.xml
+++ b/res/drawable/ic_sysbar_notification_panel.xml
@@ -1,8 +1,31 @@
-<!-- drawable/format_list_bulleted_type.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path android:fillColor="@color/icon_color_notification_panel" android:pathData="M5,9.5L7.5,14H2.5L5,9.5M3,4H7V8H3V4M5,20A2,2 0 0,0 7,18A2,2 0 0,0 5,16A2,2 0 0,0 3,18A2,2 0 0,0 5,20M9,5V7H21V5H9M9,19H21V17H9V19M9,13H21V11H9V13Z" />
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
+    <group>
+        <path
+            android:fillColor="@color/icon_color_notification_panel"
+            android:pathData="M48,80c3.3,0,6-2.7,6-6H42C42,77.3,44.7,80,48,80z" />
+        <path
+            android:fillColor="@color/icon_color_notification_panel"
+            android:pathData="M73.4,66.6L68,61.6V42h-0.1c0.1-0.7,0.1-1.3,0.1-2c0-9-5.9-16.6-14.1-19.1c-0.5-2.8-3-4.9-5.9-4.9
+s-5.4,2.1-5.9,4.9C33.9,23.4,28,31,28,40c0,0.7,0,1.3,0.1,2H28v19.6l-5.4,4.9c-0.8,0.8-0.8,2,0,2.8C23,69.8,23.5,70,24,70h4h40h4
+c0.5,0,1-0.2,1.4-0.6C74.2,68.6,74.2,67.4,73.4,66.6z" />
+    </group>
 </vector>

--- a/res/drawable/ic_sysbar_one_handed_mode_left.xml
+++ b/res/drawable/ic_sysbar_one_handed_mode_left.xml
@@ -1,39 +1,33 @@
-<!--
-     Copyright (C) 2017 ParaSHIT
+<!-- Copyright (C) 2017 The Dirty Unicorns Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
      You may obtain a copy of the License at
-            http://www.apache.org/licenses/LICENSE-2.0
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
      Unless required by applicable law or agreed to in writing, software
      distributed under the License is distributed on an "AS IS" BASIS,
      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
      See the License for the specific language governing permissions and
      limitations under the License.
-
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:width="30.0dp"
+    android:height="30.0dp"
+    android:viewportWidth="96.000000"
+    android:viewportHeight="96.000000">
 
-    <path
-        android:fillColor="@color/icon_color_one_handed_mode"
-        android:pathData="M6.0415 6.8368c0.25547-0.043254 0.07689 1.4095 0.06843 1.6094-0.06544
-1.0608-0.18021 2.6193-0.2525 3.4618-0.0642 0.76125-0.09488 1.7211 0.84244 2.6618
-0.96073-0.76494 1.8238-1.4196 2.6194-2.3669 0.78711-1.0319 1.4253-1.5097
-1.8406-1.1162 0.41529 0.39347 0.3898 0.60249-0.80233 2.2371-0.78154
-1.0716-1.2725 2.0269-1.6684 3.2447-0.30855 0.94916-0.55175 1.8375-0.82121
-2.1214-0.26945 0.28398-0.56418 1.0326-0.84716 1.5457-1.1294 0.25909-2.5978
-0.18245-3.6223 0.04484 0.26078-0.65677 0.63855-1.226
-0.97695-1.8501l-0.41532-2.5297c-0.41616-2.5279-0.41705-2.529-0.01416-3.417
-0.22177-0.48876 0.40583-1.0896 0.40824-1.3333 0.0058-0.57929 1.1344-3.6335
-1.5504-4.1957 0.05605-0.075272 0.10038-0.11171
-0.13687-0.11799zm9.4845-0.623v11.572h-4.67l-0.01889-1.9987s0.56091-0.8203
-1.1351-1.6165c1.2316-1.7077 1.1815-2.8284
-0.93684-3.5184-0.24465-0.69002-1.0164-1.1811-2.0861-1.0997-0.0029-0.83862
-0.03303-3.3391
-0.03303-3.3391zm5.075-2.6406v16.854h-11.581l0.82829-1.6259h9.3297v-13.805h-10.149l-0.05663
-5.2788s-0.4709 0.44916-1.1634 1.0997v-7.8018z" />
+    <group
+        android:translateY="96.000000"
+        android:scaleX="0.100000"
+        android:scaleY="-0.100000">
+        <path
+            android:fillColor="@color/icon_color_one_handed_mode"
+            android:strokeWidth="1"
+            android:pathData="M493 618 l-143 -142 -54 53 c-86 85 -90 80 -94 -125 -2 -156 -1 -172 16 -187 17
+-15 41 -17 188 -15 204 4 208 8 120 97 l-56 56 145 145 c80 80 145 151 145 159 0
+22 -81 101 -104 101 -12 0 -76 -56 -163 -142z" />
+    </group>
+
 </vector>

--- a/res/drawable/ic_sysbar_one_handed_mode_right.xml
+++ b/res/drawable/ic_sysbar_one_handed_mode_right.xml
@@ -1,35 +1,33 @@
-<!--
-     Copyright (C) 2017 ParaSHIT
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
      You may obtain a copy of the License at
-            http://www.apache.org/licenses/LICENSE-2.0
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
      Unless required by applicable law or agreed to in writing, software
      distributed under the License is distributed on an "AS IS" BASIS,
      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
      See the License for the specific language governing permissions and
      limitations under the License.
-
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:width="30.0dp"
+    android:height="30.0dp"
+    android:viewportWidth="96.000000"
+    android:viewportHeight="96.000000">
 
-    <path
-        android:fillColor="@color/icon_color_one_handed_mode"
-        android:pathData="M17.958 6.8368c-0.25547-0.043254-0.07689 1.4095-0.06843 1.6094 0.06544 1.0608
-0.18021 2.6193 0.2525 3.4618 0.0642 0.76125 0.09488 1.7211-0.84244
-2.6618-0.961-0.765-1.824-1.42-2.619-2.367-0.787-1.032-1.426-1.51-1.841-1.116-0.41529
-0.39347-0.3898 0.60249 0.80233 2.2371 0.78154 1.0716 1.2725 2.0269 1.6684 3.2447
-0.30855 0.94916 0.55175 1.8375 0.82121 2.1214 0.26945 0.28398 0.56418 1.0326
-0.84716 1.5457 1.1294 0.25909 2.5978 0.18245 3.6223
-0.04484-0.26078-0.65677-0.63855-1.226-0.97695-1.8501l0.41532-2.5297c0.41616-2.5279
-0.41705-2.529
-0.01416-3.417-0.22177-0.48876-0.40583-1.0896-0.40824-1.3333-0.0058-0.57929-1.1344-3.6335-1.5504-4.1957-0.05605-0.075272-0.10038-0.11171-0.13687-0.11799zm-9.4835-0.623v11.572h4.67l0.01889-1.9987s-0.56091-0.8203-1.1351-1.6165c-1.2316-1.7077-1.1815-2.8284-0.93684-3.5184
-0.24465-0.69002 1.0164-1.1811 2.0861-1.0997
-0.0029-0.83862-0.03303-3.3391-0.03303-3.3391zm-5.0759-2.6406v16.854h11.581l-0.828-1.626h-9.3305v-13.805h10.15l0.05663
-5.2788s0.4709 0.44916 1.1634 1.0997v-7.8018z" />
+    <group
+        android:translateY="96.000000"
+        android:scaleX="0.100000"
+        android:scaleY="-0.100000">
+        <path
+            android:fillColor="@color/icon_color_one_handed_mode"
+            android:strokeWidth="1"
+            android:pathData="M242 717 c-23 -23 -42 -49 -42 -58 0 -8 65 -79 145 -159 l145 -145 -56 -56 c-88
+-89 -84 -93 120 -97 147 -2 171 0 188 15 17 15 18 31 16 187 -4 205 -8 210 -94 125
+l-54 -53 -143 142 c-87 86 -151 142 -163 142 -11 0 -39 -19 -62 -43z" />
+    </group>
+
 </vector>

--- a/res/drawable/ic_sysbar_power_menu.xml
+++ b/res/drawable/ic_sysbar_power_menu.xml
@@ -1,8 +1,32 @@
-<!-- drawable/power.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path android:fillColor="@color/icon_color_power_menu" android:pathData="M16.56,5.44L15.11,6.89C16.84,7.94 18,9.83 18,12A6,6 0 0,1 12,18A6,6 0 0,1 6,12C6,9.83 7.16,7.94 8.88,6.88L7.44,5.44C5.36,6.88 4,9.28 4,12A8,8 0 0,0 12,20A8,8 0 0,0 20,12C20,9.28 18.64,6.88 16.56,5.44M13,3H11V13H13" />
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
+    <path
+        android:fillColor="@color/icon_color_power_menu"
+        android:pathData="M76.8,47.2c0-12-7.3-22.2-17.7-26.6c0,0-1.5-0.6-3.3-0.6c-1.8,0-3.3,1.5-3.3,3.3V25v22.2c0,2.4-2,4.4-4.4,4.4
+s-4.4-2-4.4-4.4V25v-1.7c0-1.8-1.5-3.3-3.3-3.3c-1.8,0-3.3,0.6-3.3,0.6c-10.4,4.3-17.7,14.6-17.7,26.6c0,3.1,0.5,6.1,1.4,8.9h0
+c0,0.2,0.1,0.3,0.2,0.5c0.2,0.5,0.4,1,0.6,1.5c0.1,0.3,0.2,0.5,0.3,0.8c0.2,0.4,0.4,0.8,0.6,1.2c0.1,0.3,0.3,0.6,0.5,0.9
+c0.2,0.3,0.4,0.7,0.6,1c0.2,0.3,0.4,0.7,0.6,1c0.2,0.3,0.3,0.5,0.5,0.8c0.2,0.4,0.5,0.7,0.8,1c0.2,0.2,0.3,0.4,0.5,0.6
+c0.3,0.4,0.6,0.7,0.9,1.1c0.1,0.2,0.3,0.3,0.4,0.4c0.4,0.4,0.7,0.8,1.1,1.1c0.1,0.1,0.2,0.2,0.3,0.3c0.4,0.4,0.9,0.8,1.3,1.2
+c0.1,0,0.1,0.1,0.2,0.1c5,4,11.3,6.5,18.2,6.5s13.2-2.4,18.2-6.5c0.1,0,0.1-0.1,0.2-0.1c0.5-0.4,0.9-0.8,1.3-1.2
+c0.1-0.1,0.2-0.2,0.3-0.3c0.4-0.4,0.8-0.7,1.1-1.1c0.1-0.1,0.3-0.3,0.4-0.4c0.3-0.4,0.6-0.7,0.9-1.1c0.2-0.2,0.3-0.4,0.5-0.6
+c0.3-0.3,0.5-0.7,0.8-1c0.2-0.3,0.4-0.5,0.5-0.8c0.2-0.3,0.4-0.6,0.6-1c0.2-0.3,0.4-0.7,0.6-1c0.2-0.3,0.3-0.6,0.5-0.9
+c0.2-0.4,0.4-0.8,0.6-1.2c0.1-0.3,0.2-0.5,0.3-0.8c0.2-0.5,0.4-1,0.6-1.5c0.1-0.2,0.1-0.3,0.2-0.5h0C76.3,53.2,76.8,50.3,76.8,47.2z" />
 </vector>

--- a/res/drawable/ic_sysbar_recent.xml
+++ b/res/drawable/ic_sysbar_recent.xml
@@ -1,34 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-    Copyright (c) 2015 SlimRoms
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
 
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+          http://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="15.994dp"
-    android:height="16dp"
-    android:viewportWidth="15.994"
-    android:viewportHeight="16">
+        android:width="28.0dp"
+        android:height="28.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
 
     <path
         android:fillColor="@color/icon_color_overview"
-        android:pathData="M1.3726
-15.991c-0.44225-0.05-0.85907-0.307-1.1131-0.685-0.12559-0.188-0.2033-0.386-0.24654-0.628-0.017518-0.098-0.017518-13.257-0.000006-13.354
-0.032624-0.183 0.083475-0.33675 0.15818-0.47875 0.24568-0.46682 0.69859-0.77903
-1.2121-0.83553 0.1154-0.012711 13.112-0.013066 13.226-0.0004167 0.179 0.020001
-0.338 0.065692 0.501 0.14393 0.467 0.22422 0.793 0.66542 0.872 1.1791 0.009
-0.0608 0.012 1.2834 0.012 6.6684 0 5.3853-0.002 6.6083-0.012 6.6683-0.108
-0.701-0.671 1.245-1.373 1.323-0.098 0.011-13.14
-0.011-13.236-0.001zm12.609-7.9903v-5.9762h-5.9846-5.985v5.9762 5.9763h5.985
-5.9846v-5.9763z" />
+        android:pathData="M70,76H26c-3.3,0-6-2.7-6-6V26c0-3.3,2.7-6,6-6h44c3.3,0,6,2.7,6,6v44C76,73.3,73.3,76,70,76z" />
 </vector>

--- a/res/drawable/ic_sysbar_recent_land.xml
+++ b/res/drawable/ic_sysbar_recent_land.xml
@@ -1,34 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-    Copyright (c) 2015 SlimRoms
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
 
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+          http://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="15.994dp"
-    android:height="16dp"
-    android:viewportWidth="15.994"
-    android:viewportHeight="16">
+        android:width="28.0dp"
+        android:height="28.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
 
     <path
         android:fillColor="@color/icon_color_overview"
-        android:pathData="M1.3726
-15.991c-0.44225-0.05-0.85907-0.307-1.1131-0.685-0.12559-0.188-0.2033-0.386-0.24654-0.628-0.017518-0.098-0.017518-13.257-0.000006-13.354
-0.032624-0.183 0.083475-0.33675 0.15818-0.47875 0.24568-0.46682 0.69859-0.77903
-1.2121-0.83553 0.1154-0.012711 13.112-0.013066 13.226-0.0004167 0.179 0.020001
-0.338 0.065692 0.501 0.14393 0.467 0.22422 0.793 0.66542 0.872 1.1791 0.009
-0.0608 0.012 1.2834 0.012 6.6684 0 5.3853-0.002 6.6083-0.012 6.6683-0.108
-0.701-0.671 1.245-1.373 1.323-0.098 0.011-13.14
-0.011-13.236-0.001zm12.609-7.9903v-5.9762h-5.9846-5.985v5.9762 5.9763h5.985
-5.9846v-5.9763z" />
+        android:pathData="M70,76H26c-3.3,0-6-2.7-6-6V26c0-3.3,2.7-6,6-6h44c3.3,0,6,2.7,6,6v44C76,73.3,73.3,76,70,76z" />
 </vector>

--- a/res/drawable/ic_sysbar_record_screen.xml
+++ b/res/drawable/ic_sysbar_record_screen.xml
@@ -1,8 +1,31 @@
-<!-- drawable/file_video.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path android:fillColor="@color/icon_color_screenrecord" android:pathData="M13,9H18.5L13,3.5V9M6,2H14L20,8V20A2,2 0 0,1 18,22H6C4.89,22 4,21.1 4,20V4C4,2.89 4.89,2 6,2M17,19V13L14,15.2V13H7V19H14V16.8L17,19Z" />
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
+    <group>
+        <path
+            android:fillColor="@color/icon_color_screenrecord"
+            android:pathData="M79,30c-0.5,0-1,0.2-1.5,0.4l0,0l-11.6,5.8c-0.1,0-0.2,0.1-0.3,0.2l-0.1,0.1l0,0C64.6,37,64,37.9,64,39v18
+c0,1,0.5,1.9,1.3,2.5l0,0l0,0c0.2,0.2,0.5,0.3,0.7,0.4l11.5,5.8l0,0C78,65.8,78.5,66,79,66c1.7,0,3-1.3,3-3V33
+C82,31.3,80.7,30,79,30z" />
+        <path
+            android:fillColor="@color/icon_color_screenrecord"
+            android:pathData="M52,26H22h-2c-3.3,0-6,2.7-6,6v32c0,3.3,2.7,6,6,6h32c3.3,0,6-2.7,6-6v-2V32C58,28.7,55.3,26,52,26z" />
+    </group>
 </vector>

--- a/res/drawable/ic_sysbar_region_screenshot.xml
+++ b/res/drawable/ic_sysbar_region_screenshot.xml
@@ -1,42 +1,31 @@
-<!-- drawable/image_filter.xml -->
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
 
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
     <path
         android:fillColor="@color/icon_color_region_screenshot"
-        android:pathData="M7,1 A2,2,0,0,0,5,3 L5,17 A2,2,0,0,0,7,19 L21,19 A2,2,0,0,0,23,17 L23,3
-A2,2,0,0,0,21,1 L7,1 Z M7,3 L21,3 L21,17 L7,17 L7,3 Z" />
+        android:pathData="M82,36H64c-2.2,0-4-1.8-4-4V14c0-2.2,1.8-4,4-4h18c2.2,0,4,1.8,4,4v18C86,34.2,84.2,36,82,36z" />
     <path
         android:fillColor="@color/icon_color_region_screenshot"
-        android:pathData="M3,5 L1,5 L1,21 A2,2,0,0,0,3,23 L19,23 L19,21 L3,21" />
-    <path
-        android:fillColor="@color/icon_color_region_screenshot"
-        android:pathData="M8.05509,6.21535 C8.7421,6.21535,9.35864,6.21535,10.0633,6.21535
-C10.0633,5.52834,10.0633,4.85895,10.0633,4.15433
-C10.4685,4.15433,10.7679,4.15433,11.1378,4.15433
-C11.1378,6.93758,11.1378,9.6856,11.1378,12.5393
-C13.9739,12.5393,16.7395,12.5393,19.558,12.5393
-C19.558,12.9268,19.558,13.2087,19.558,13.5962
-C18.9062,13.5962,18.2368,13.5962,17.5146,13.5962
-C17.5146,14.3361,17.5146,14.9702,17.5146,15.6572
-C17.1447,15.6572,16.8452,15.6572,16.4753,15.6572
-C16.4753,15.023,16.4753,14.3889,16.4753,13.6138
-C15.4184,13.6138,14.4495,13.6138,13.463,13.6138
-C12.7584,13.6138,12.0538,13.6314,11.3491,13.6138
-C10.4859,13.5962,10.116,13.2263,10.116,12.3631
-C10.0984,10.6896,10.116,9.03377,10.116,7.28983
-C9.39376,7.28983,8.75961,7.28983,8.0726,7.28983
-C8.05498,6.9199,8.05498,6.62044,8.05498,6.21528 Z" />
-    <path
-        android:fillColor="@color/icon_color_region_screenshot"
-        android:pathData="M16.4577,7.27228 C14.9956,7.27228,13.6568,7.27228,12.2652,7.27228
-C12.2652,6.90235,12.2652,6.60289,12.2652,6.21535
-C13.6921,6.21535,15.0837,6.19773,16.4929,6.23298
-C17.0918,6.25061,17.4794,6.65575,17.4794,7.25468
-C17.497,8.62869,17.4794,10.0027,17.4794,11.4296
-C17.1271,11.4296,16.8276,11.4296,16.4577,11.4296
-C16.4577,10.0908,16.4577,8.75204,16.4577,7.27234 Z" />
+        android:pathData="M72,42h-2h-2h-8c-3.3,0-6-2.7-6-6v-8v-2v-2c0-2.2-1.8-4-4-4h-2H27c-3.8,0-7,3.2-7,7v42c0,3.8,3.2,7,7,7h42
+c3.8,0,7-3.2,7-7V48v-2C76,43.8,74.2,42,72,42z
+M65,66h-9h-6h-2H31c-1.7,0-3-1.3-3-3c0-0.6,0.2-1.1,0.5-1.6l0,0l0,0
+c0-0.1,0.1-0.1,0.1-0.2l9.9-13.8C39,46.6,39.9,46,41,46c1.1,0,2.1,0.6,2.6,1.5L52,60l4.4-6.6h0c0.5-0.9,1.5-1.5,2.6-1.5
+s2.1,0.6,2.6,1.5h0l5.7,7.6c0.1,0.1,0.1,0.2,0.2,0.3l0,0l0,0c0.3,0.5,0.5,1,0.5,1.6C68,64.7,66.7,66,65,66z" />
 </vector>

--- a/res/drawable/ic_sysbar_screen_off.xml
+++ b/res/drawable/ic_sysbar_screen_off.xml
@@ -1,8 +1,39 @@
-<!-- drawable/sleep.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path android:fillColor="@color/icon_color_screen_off" android:pathData="M23,12H17V10L20.39,6H17V4H23V6L19.62,10H23V12M15,16H9V14L12.39,10H9V8H15V10L11.62,14H15V16M7,20H1V18L4.39,14H1V12H7V14L3.62,18H7V20Z" />
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
+
+    <group>
+        <path
+            android:fillColor="@color/icon_color_screen_off"
+            android:pathData="M44,14H16c-1.1,0-2,0.9-2,2v6c0,1.1,0.9,2,2,2h17.2L14.7,42.5h0C14.3,42.9,14,43.4,14,44v6c0,1.1,0.9,2,2,2
+h28c1.1,0,2-0.9,2-2v-6c0-1.1-0.9-2-2-2H26.8l18.5-18.5c0.1-0.1,0.2-0.2,0.3-0.3l0,0c0.3-0.3,0.5-0.8,0.5-1.3v-6
+C46,14.9,45.1,14,44,14z" />
+        <path
+            android:fillColor="@color/icon_color_screen_off"
+            android:pathData="M44,60H28c-1.1,0-2,0.9-2,2v2c0,1.1,0.9,2,2,2h9.2L26.6,76.6l0,0C26.2,76.9,26,77.4,26,78v2
+c0,1.1,0.9,2,2,2h16c1.1,0,2-0.9,2-2v-2c0-1.1-0.9-2-2-2h-9.2l10.5-10.5c0.1-0.1,0.2-0.2,0.3-0.3l0,0h0c0.3-0.3,0.5-0.8,0.5-1.3v-2
+C46,60.9,45.1,60,44,60z" />
+        <path
+            android:fillColor="@color/icon_color_screen_off"
+            android:pathData="M81.6,41.2L81.6,41.2c0.3-0.3,0.4-0.8,0.4-1.2v-4c0-1.1-0.9-2-2-2H56c-1.1,0-2,0.9-2,2v4c0,1.1,0.9,2,2,2
+h13.2L54.7,56.5C54.3,56.8,54,57.4,54,58v4c0,1.1,0.9,2,2,2h24c1.1,0,2-0.9,2-2v-4c0-1.1-0.9-2-2-2H66.8l14.4-14.4
+C81.3,41.5,81.5,41.3,81.6,41.2z" />
+    </group>
 </vector>

--- a/res/drawable/ic_sysbar_screenshot.xml
+++ b/res/drawable/ic_sysbar_screenshot.xml
@@ -1,8 +1,28 @@
-<!-- drawable/image_filter.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path android:fillColor="@color/icon_color_screenshot" android:pathData="M21,17H7V3H21M21,1H7A2,2 0 0,0 5,3V17A2,2 0 0,0 7,19H21A2,2 0 0,0 23,17V3A2,2 0 0,0 21,1M3,5H1V21A2,2 0 0,0 3,23H19V21H3M15.96,10.29L13.21,13.83L11.25,11.47L8.5,15H19.5L15.96,10.29Z" />
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
+    <path
+        android:fillColor="@color/icon_color_screenshot"
+        android:pathData="M69,20H27c-3.8,0-7,3.2-7,7v42c0,3.8,3.2,7,7,7h42c3.8,0,7-3.2,7-7V27C76,23.2,72.8,20,69,20z
+M65,66h-9h-6
+h-2H31c-1.7,0-3-1.3-3-3c0-0.6,0.2-1.1,0.5-1.6l0,0l0,0c0-0.1,0.1-0.1,0.1-0.2l9.9-13.8C39,46.6,39.9,46,41,46
+c1.1,0,2.1,0.6,2.6,1.5L52,60l4.4-6.6h0c0.5-0.9,1.5-1.5,2.6-1.5s2.1,0.6,2.6,1.5h0l5.7,7.6c0.1,0.1,0.1,0.2,0.2,0.3l0,0l0,0
+c0.3,0.5,0.5,1,0.5,1.6C68,64.7,66.7,66,65,66z" />
 </vector>

--- a/res/drawable/ic_sysbar_search.xml
+++ b/res/drawable/ic_sysbar_search.xml
@@ -1,8 +1,30 @@
-<!-- drawable/file_find.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path android:fillColor="@color/icon_color_voice_search" android:pathData="M9,13A3,3 0 0,0 12,16A3,3 0 0,0 15,13A3,3 0 0,0 12,10A3,3 0 0,0 9,13M20,19.59V8L14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18C18.45,22 18.85,21.85 19.19,21.6L14.76,17.17C13.96,17.69 13,18 12,18A5,5 0 0,1 7,13A5,5 0 0,1 12,8A5,5 0 0,1 17,13C17,14 16.69,14.96 16.17,15.75L20,19.59Z" />
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
+    <group>
+        <path
+            android:fillColor="@color/icon_color_voice_search"
+            android:pathData="M72,32h-4c-1.1,0-2,0.9-2,2v10c0,9.9-8.1,18-18,18s-18-8.1-18-18V34c0-1.1-0.9-2-2-2h-4c-1.1,0-2,0.9-2,2
+v10c0,12.3,8.5,22.6,20,25.3V76c0,1.1,0.9,2,2,2h1h6h1c1.1,0,2-0.9,2-2v-6.7c11.5-2.7,20-13,20-25.3V34C74,32.9,73.1,32,72,32z" />
+        <path
+            android:fillColor="@color/icon_color_voice_search"
+            android:pathData="M48,56c6.6,0,12-5.4,12-12V30c0-6.6-5.4-12-12-12s-12,5.4-12,12v14C36,50.6,41.4,56,48,56z" />
+    </group>
 </vector>

--- a/res/drawable/ic_sysbar_settings_panel.xml
+++ b/res/drawable/ic_sysbar_settings_panel.xml
@@ -1,8 +1,30 @@
-<!-- drawable/settings_box.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path android:fillColor="@color/icon_color_settings_panel" android:pathData="M17.25,12C17.25,12.23 17.23,12.46 17.2,12.68L18.68,13.84C18.81,13.95 18.85,14.13 18.76,14.29L17.36,16.71C17.27,16.86 17.09,16.92 16.93,16.86L15.19,16.16C14.83,16.44 14.43,16.67 14,16.85L13.75,18.7C13.72,18.87 13.57,19 13.4,19H10.6C10.43,19 10.28,18.87 10.25,18.7L10,16.85C9.56,16.67 9.17,16.44 8.81,16.16L7.07,16.86C6.91,16.92 6.73,16.86 6.64,16.71L5.24,14.29C5.15,14.13 5.19,13.95 5.32,13.84L6.8,12.68C6.77,12.46 6.75,12.23 6.75,12C6.75,11.77 6.77,11.54 6.8,11.32L5.32,10.16C5.19,10.05 5.15,9.86 5.24,9.71L6.64,7.29C6.73,7.13 6.91,7.07 7.07,7.13L8.81,7.84C9.17,7.56 9.56,7.32 10,7.15L10.25,5.29C10.28,5.13 10.43,5 10.6,5H13.4C13.57,5 13.72,5.13 13.75,5.29L14,7.15C14.43,7.32 14.83,7.56 15.19,7.84L16.93,7.13C17.09,7.07 17.27,7.13 17.36,7.29L18.76,9.71C18.85,9.86 18.81,10.05 18.68,10.16L17.2,11.32C17.23,11.54 17.25,11.77 17.25,12M19,3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3M12,10C10.89,10 10,10.89 10,12A2,2 0 0,0 12,14A2,2 0 0,0 14,12C14,10.89 13.1,10 12,10Z" />
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
+    <path
+        android:fillColor="@color/icon_color_settings_panel"
+        android:pathData="M75.6,55.3L68,50.9h0c-4.9-2.8,0-5.7,0-5.7l7.6-4.4c1.2-0.7,1.6-2.2,0.9-3.4l-5-8.7c-0.7-1.2-2.2-1.6-3.4-0.9
+l-7.9,4.6c-0.4,0.2-4.6,1.9-4.6-2.6h0v-9.3c0-1.4-1.1-2.5-2.5-2.5H43c-1.4,0-2.5,1.1-2.5,2.5v9.3c0,4.6-4.7,2.6-4.7,2.6l-7.9-4.6
+c-1.2-0.7-2.7-0.3-3.4,0.9l-5,8.7c-0.7,1.2-0.3,2.7,0.9,3.4l7.6,4.4h0c0,0,4.9,2.9,0,5.7h0l-7.6,4.4c-1.2,0.7-1.6,2.2-0.9,3.4l5,8.7
+c0.7,1.2,2.2,1.6,3.4,0.9l8.1-4.7c0.9-0.3,4.4-1.4,4.4,2.6h0v9.3c0,1.4,1.1,2.5,2.5,2.5h10c1.4,0,2.5-1.1,2.5-2.5v-9.3h0
+c0-4,3.5-3,4.4-2.6l8.1,4.7c1.2,0.7,2.7,0.3,3.4-0.9l5-8.7C77.2,57.5,76.8,55.9,75.6,55.3z
+M48,54.4c-3.6,0-6.4-2.9-6.4-6.4
+s2.9-6.4,6.4-6.4s6.4,2.9,6.4,6.4S51.6,54.4,48,54.4z" />
 </vector>

--- a/res/drawable/ic_sysbar_torch.xml
+++ b/res/drawable/ic_sysbar_torch.xml
@@ -1,8 +1,28 @@
-<!-- drawable/flashlight.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path android:fillColor="@color/icon_color_flashlight" android:pathData="M9,10L6,5H18L15,10H9M18,4H6V2H18V4M9,22V11H15V22H9M12,13A1,1 0 0,0 11,14A1,1 0 0,0 12,15A1,1 0 0,0 13,14A1,1 0 0,0 12,13Z" />
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
+
+    <path
+        android:fillColor="@color/icon_color_flashlight"
+        android:pathData="M65,47.9c0.1-0.1,0.1-0.2,0.2-0.3l0.1-0.1l0,0c0.5-0.8,0.7-1.6,0.7-2.6c0-2.8-2.2-5-5-5h-9l10-14l0,0
+c0.6-0.8,1-1.9,1-3c0-2.8-2.2-5-5-5H39c-2.4,0-4.5,1.7-4.9,4.1l0,0l-4,23.8c0,0.1,0,0.2-0.1,0.4L30,46.6l0,0c0,0.1,0,0.3,0,0.4
+c0,2.8,2.2,5,5,5h13l-9.5,20.1c-0.1,0.2-0.2,0.3-0.2,0.5l0,0.1l0,0C38.1,73.1,38,73.5,38,74c0,2.2,1.8,4,4,4c1.3,0,2.5-0.7,3.2-1.7
+l0,0l0-0.1c0,0,0-0.1,0.1-0.1L65,47.9z" />
 </vector>

--- a/res/drawable/ic_sysbar_volume_panel.xml
+++ b/res/drawable/ic_sysbar_volume_panel.xml
@@ -1,8 +1,31 @@
-<!-- drawable/volume_panel.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path android:fillColor="@color/icon_color_volume_panel" android:pathData="M14,3.23V5.29C16.89,6.15 19,8.83 19,12C19,15.17 16.89,17.84 14,18.7V20.77C18,19.86 21,16.28 21,12C21,7.72 18,4.14 14,3.23M16.5,12C16.5,10.23 15.5,8.71 14,7.97V16C15.5,15.29 16.5,13.76 16.5,12M3,9V15H7L12,20V4L7,9H3Z" />
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
+    <group>
+        <path
+            android:fillColor="@color/icon_color_volume_panel"
+            android:pathData="M54,22c-0.5,0-1,0.1-1.5,0.3l0,0l0,0c-0.3,0.1-0.5,0.3-0.8,0.4L34.8,32H16c-3.3,0-6,2.7-6,6v2v16v2
+c0,3.3,2.7,6,6,6h18.8l16.9,9.3c0.6,0.4,1.4,0.7,2.3,0.7c2.2,0,4-1.8,4-4V26C58,23.8,56.2,22,54,22z" />
+        <path
+            android:fillColor="@color/icon_color_volume_panel"
+            android:pathData="M86,32c0-2.2-1.8-4-4-4h-8c-2.2,0-4,1.8-4,4v32c0,2.2,1.8,4,4,4c1.8,0,3.3-1.2,3.8-2.9l0,0l0.1-0.3l0,0l0,0
+c0,0,0,0,0,0l8-31.9l0,0C86,32.6,86,32.3,86,32z" />
+    </group>
 </vector>

--- a/res/drawable/ic_sysbar_wifi.xml
+++ b/res/drawable/ic_sysbar_wifi.xml
@@ -1,8 +1,30 @@
-<!-- drawable/wifi.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2017 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path android:fillColor="@color/icon_color_wifi" android:pathData="M12,21L15.6,16.2C14.6,15.45 13.35,15 12,15C10.65,15 9.4,15.45 8.4,16.2L12,21M12,3C7.95,3 4.21,4.34 1.2,6.6L3,9C5.5,7.12 8.62,6 12,6C15.38,6 18.5,7.12 21,9L22.8,6.6C19.79,4.34 16.05,3 12,3M12,9C9.3,9 6.81,9.89 4.8,11.4L6.6,13.8C8.1,12.67 9.97,12 12,12C14.03,12 15.9,12.67 17.4,13.8L19.2,11.4C17.19,9.89 14.7,9 12,9Z" />
+        android:width="30.0dp"
+        android:height="30.0dp"
+        android:viewportWidth="96.0"
+        android:viewportHeight="96.0">
+
+    <path
+        android:fillColor="@color/icon_color_wifi"
+        android:pathData="M78.2,25.4c0-3-2.4-5.4-5.4-5.4H23.2c-3,0-5.4,2.4-5.4,5.4c0,0.9,0.2,1.6,0.6,2.4l0,0l24,45l0,0
+c0.1,0.1,0.1,0.2,0.2,0.3c1.2,1.8,3.1,2.9,5.4,2.9s4.3-1.2,5.4-2.9c0.1-0.1,0.1-0.2,0.2-0.4l0,0l11.2-21l12.6-23.5l0,0
+c0.2-0.3,0.3-0.5,0.4-0.8l0,0l0,0C78,26.8,78.2,26.1,78.2,25.4z
+M65.9,30.6L65.9,30.6c-0.1,0.2-0.2,0.4-0.3,0.5l-2.8,5.6
+c0,0.1,0,0.1-0.1,0.1l0,0l0,0c-0.3,0.6-1,1.1-1.8,1.1H35c-0.7,0-1.3-0.4-1.7-1l0,0l0-0.1c0-0.1-0.1-0.2-0.1-0.3l-2.8-5.6
+c-0.1-0.2-0.2-0.3-0.3-0.5l0,0l0,0C30,30.4,30,30.2,30,30c0-1.1,0.9-2,2-2h32c1.1,0,2,0.9,2,2C66,30.2,66,30.4,65.9,30.6L65.9,30.6z" />
 </vector>


### PR DESCRIPTION
A few weeks ago we made the change system wide from Material teal to
Pixel blue. This changed was welcomed with open arms by many.  With this
change came the pixel navbar icons for 'back/home/recents' and while
this change was also welcomed, it looked off (at least to us) when you
enabled other icons.

So what we did was reach out to the talented Rahul K Dinesh​ and he delivered!

He has made beautiful icons for us that fit perfectly with the traditional
pixel navbar icons and we couldn't be happier :-)

Make sure to check out his other work in the playstore and on Google+!

https://play.google.com/store/apps/details?id=com.b16h22.rubiq
https://play.google.com/store/apps/details?id=com.b16h22.navswag

https://plus.google.com/u/1/106222165086709621824

Change-Id: I94f7a23eb1d253b8e84fb4ad1f5c6b8fb6a9cec0
Signed-off-by: AmolAmrit <amol.amrit03@outlook.com>